### PR TITLE
scheme agnostic static urls

### DIFF
--- a/uwsgi_sloth/settings.py
+++ b/uwsgi_sloth/settings.py
@@ -10,12 +10,10 @@ LIMIT_URL_GROUPS = 200
 LIMIT_PER_URL_GROUP = 20
 DEFAULT_MIN_MSECS = 200
 
-STATIC_PATH_BOOTSTRAP = 'http://maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css'
-STATIC_PATH_JQUERY = 'http://code.jquery.com/jquery-1.7.2.min.js'
+STATIC_PATH_BOOTSTRAP = '//maxcdn.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css'
+STATIC_PATH_JQUERY = '//code.jquery.com/jquery-1.7.2.min.js'
 
-STATIC_PATH_SORTABLE_CSS = 'https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/css/sortable-theme-bootstrap.min.css'
-STATIC_PATH_SORTABLE = 'https://cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js'
+STATIC_PATH_SORTABLE_CSS = '//cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/css/sortable-theme-bootstrap.min.css'
+STATIC_PATH_SORTABLE = '//cdnjs.cloudflare.com/ajax/libs/sortable/0.8.0/js/sortable.min.js'
 
 REALTIME_UPDATE_INTERVAL = 5 * 60
-
-


### PR DESCRIPTION
Now, if you open the report on a HTTPS site, it will work. 