### PR TITLE
template: fixup version in template context

### DIFF
--- a/uwsgi_sloth/template.py
+++ b/uwsgi_sloth/template.py
@@ -33,7 +33,7 @@ def render_template(template_name, context={}):
     context.update(
         SETTINGS=settings,
         now=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        version='.'.join(map(str, __VERSION__)))
+        version=__VERSION__)
     return template.render(**context)
 
 


### PR DESCRIPTION
`__VERSION__` is already a string, no need to poke with it.